### PR TITLE
Changing 'token' to 'password' and fixing cancelScheduledSms test

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ zcs.events.on('event', (data)=>{
 ```javascript
 /**
  * Available methods:
- *      setCredentials(account, token) - Set API Credentials
+ *      setCredentials(account, password) - Set API Credentials
  *      sendSMS(payload) - Send unique and multiple SMS
  *      getSMSStatus(sms_id) - Get SMS status by ID
  *      getSMSReceivedList() - Get received SMS list
@@ -39,7 +39,7 @@ zcs.events.on('event', (data)=>{
 
 const zapi = require('@zenvia/zenvia-sms-core').api;
 
-zapi.setCredentials('account', 'token');
+zapi.setCredentials('account', 'password');
 
 /* Send unique short and long SMS example
  */
@@ -69,7 +69,7 @@ zapi.setCredentials('account', 'token');
 run `npm install`.
 
 ### Make tests
-for success send SMS tests case in api, fill `phone_number`, `zenvia_account`, `zenvia_token` on `test/api.test.js`.
+for success send SMS tests case in api, fill `phone_number`, `zenvia_account`, `zenvia_password` on `test/api.test.js`.
 
 run `npm test`.
 

--- a/_code_examples/api.js
+++ b/_code_examples/api.js
@@ -5,7 +5,7 @@
  * Zenvia SMS API - Usage Examples
  *
  * Functions:
- *      setCredentials(account, token) - Set API Credentials
+ *      setCredentials(account, password) - Set API Credentials
  *      sendSMS(payload) - Send unique and multiple SMS
  *      getSMSStatus(sms_id) - Get SMS status by ID
  *      getSMSReceivedList() - Get received SMS list
@@ -16,7 +16,7 @@
 
 const zapi = require('../index').api;
 
-zapi.setCredentials('account', 'token');
+zapi.setCredentials('account', 'password');
 
 /* Send unique short and long SMS example
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,7 +5,7 @@
  * Zenvia SMS API
  *
  * Functions:
- *      setCredentials(account, token) - Set API Credentials
+ *      setCredentials(account, password) - Set API Credentials
  *      sendSMS(payload) - Send unique and multiple SMS
  *      getSMSStatus(sms_id) - Get SMS status by ID
  *      getSMSReceivedList() - Get received SMS list
@@ -39,12 +39,12 @@ module.exports = {
 
     CREDENTIALS: {
         account: null,
-        token: null,
+        password: null,
     },
 
-    setCredentials(account, token){
+    setCredentials(account, password){
         this.CREDENTIALS.account = account;
-        this.CREDENTIALS.token = token;
+        this.CREDENTIALS.password = password;
     },
 
     sendSMS(payload){
@@ -62,7 +62,7 @@ module.exports = {
                 .send(payload)
                 .auth({
                     user: this.CREDENTIALS.account,
-                    pass: this.CREDENTIALS.token
+                    pass: this.CREDENTIALS.password
                 })
                 .end(function (response) {
 
@@ -91,7 +91,7 @@ module.exports = {
                 .headers({'Accept': 'application/octet-stream', 'Content-Type': 'application/octet-stream'})
                 .auth({
                     user: this.CREDENTIALS.account,
-                    pass: this.CREDENTIALS.token
+                    pass: this.CREDENTIALS.password
                 })
                 .end(function (response) {
 
@@ -120,7 +120,7 @@ module.exports = {
                 .headers(this.DEFAULT_HEADER)
                 .auth({
                     user: this.CREDENTIALS.account,
-                    pass: this.CREDENTIALS.token
+                    pass: this.CREDENTIALS.password
                 })
                 .end(function (response) {
 
@@ -149,7 +149,7 @@ module.exports = {
                 .headers(this.DEFAULT_HEADER)
                 .auth({
                     user: this.CREDENTIALS.account,
-                    pass: this.CREDENTIALS.token
+                    pass: this.CREDENTIALS.password
                 })
                 .end(function (response) {
 
@@ -177,7 +177,7 @@ module.exports = {
                 .headers(this.DEFAULT_HEADER)
                 .auth({
                     user: this.CREDENTIALS.account,
-                    pass: this.CREDENTIALS.token
+                    pass: this.CREDENTIALS.password
                 })
                 .end(function (response) {
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -7,10 +7,10 @@ describe('API', ()=>{
 
     const phone_number = '5551999999999';
     const zenvia_account = 'acc.count';
-    const zenvia_token = 'aNythInK';
+    const zenvia_password = 'aNythInK';
 
     beforeEach(()=>{
-        zapi.setCredentials(zenvia_account, zenvia_token);
+        zapi.setCredentials(zenvia_account, zenvia_password);
     });
 
     it('should set credentials', () => {
@@ -22,7 +22,7 @@ describe('API', ()=>{
             .equal(
                 JSON.stringify({
                     account: 'abc',
-                    token: '123',
+                    password: '123',
                 })
             );
 
@@ -261,7 +261,7 @@ describe('API', ()=>{
             sendSmsRequest: {
                 from: "Zenvia API",
                 to: phone_number,
-                schedule: Date.now(),
+                schedule: Date.now() + 10000,
                 msg: "Hello from Zenvia API from NodeJS!!!",
                 callbackOption: "NONE",
                 id: sms_id,


### PR DESCRIPTION
The name 'token' at setCredentials function, may confuse users with
access tokens, where there is no need to use account and password to
access.

I changed that, besides that, the cancelScheduledSms test was trying
canceling a sms scheduled to now(). That was causing failure, i added
a time to the date so the test was able to cancel it.